### PR TITLE
Refactored HackerOne report scraper with error handling and memory optimizations

### DIFF
--- a/hackerone.py
+++ b/hackerone.py
@@ -1,175 +1,267 @@
-import requests
+#!/usr/bin/env python3
 import json
+from argparse import ArgumentParser
+from time import sleep
+from typing import Generator
 
-reportUrls = set()
-session = requests.session()
+import httpx
 
-graphql_url = "https://hackerone.com:443/graphql"
-cookies = {
-  "__Host-session": "aXBIbjB1STREL3V6RTBuaTY2blRWUHh1N2tXSkhqbjhGU2daVnZiSFh0L3BZSkJLUk5Nd0tNdVp5OFFnVGtobDJIeHo0eEJQSTNlMGxIMVlCSkZqM1Y1NytGa0dpN2lPVGVJT2FtUS9lTXhpOXBlb2VnWmdhSERDUW5mM0FyUGthWktZU1JHN1VWUytxU1RTbjZVcWFoa2FPVk9BenJjOC9WelNwNnhpQkNtNzAvQ3ltN05rMjVVMXloaVhpTDNaZGdIdmtYTStGV0tMWnZLd0ZIRExqOWRMcDZsajVtaUh6ZFVtUFNQK0VTb1d6ZTZtZzh3YjdQVzVZS0lKTUpEOEFXQXdmN2sza0J1NElvaGM5VlByTTdDLzJqZlFSOTlteG0wWlozZ3hEOUdDckpteWZNR3U2amhhUU9MRlZvbU5LNzZYYXhRRVUvdC9FQmxNSUxQZmkycnN0OS9MNG5Ha3pMLzFLUmdZRUtkZm52d1QxeVFIVlpQbmVyVWJ5eHJxcEZla3ltL2hXVnlLZ1h5bGFrSHVQTklRRkVmMEZaZmNreTJ2RWtTU1Rja2hNajJFS1pKN0VOek9VT0tGd3JjRHZRTWgvd3NZeFh4b0lhNFJ3WUNtNFUrOVgvd1ZScTBTU3RLZVQreGtKNFJ3ZU5YZUQzV3d5VWx1Q1dJM1crTFBwS3FQQjE0dzRrcDRlMTM3QWlpZ0NSYXRocElJODkxRWZudW8rY25Jd2dvaGs5OFo1SmhFclMxTDJheHpudUQyV0dJNzJ3bEFUZS80Vk9iZDJ4WHdJTjVnY21DNTYrK1Zwd1NML2hwcEFYR2dORnA0am9OUHNvT2xqSlVZZzNBLzJGS3FML21RWXhwTG9MVzhZalV5R1BiNHZzNE9hOG5UZzh5SXhDWUhYNHM9LS1icmhNRlVhZGlLZ1BYSGZpS2NsR05BPT0%3D--97ba3ea41d896ed935aab5e393c12d8d7b0fb074"}
-headers = {"Content-Type": "application/json", "X-Csrf-Token": "bvyy75cEacX1ywOPQdOx1Xqf8dAztwxkNUnS9aKg20OUCkvGuc8Urs9R+MhvIWmcDR5iIo2los4cS7gTJ2VWNw=="}
-query_string = """
-query HacktivityPageQuery($querystring: String, $orderBy: HacktivityItemOrderInput, $secureOrderBy: FiltersHacktivityItemFilterOrder, $where: FiltersHacktivityItemFilterInput, $count: Int, $cursor: String) {
-  me {
-    id
-    __typename
-  }
-  hacktivity_items(
-    first: $count
-    after: $cursor
-    query: $querystring
-    order_by: $orderBy
-    secure_order_by: $secureOrderBy
-    where: $where
-  ) {
-    ...HacktivityList
-    __typename
-  }
-}
 
-fragment HacktivityList on HacktivityItemConnection {
-  pageInfo {
-    endCursor
-    hasNextPage
-    __typename
-  }
-  edges {
-    node {
-      ... on HacktivityItemInterface {
-        id
-        databaseId: _id
-        __typename
-      }
-      __typename
-    }
-    ...HacktivityItem
-    __typename
-  }
-  __typename
-}
+class HackerOneSession:
+    """Client to interact with HackerOne API."""
 
-fragment HacktivityItem on HacktivityItemUnionEdge {
-  node {
-    ... on HacktivityItemInterface {
-      id
-      type: __typename
-    }
-    ... on Disclosed {
-      id
-      ...HacktivityItemDisclosed
-      __typename
-    }
-    __typename
-  }
-  __typename
-}
+    def __init__(
+        self,
+        cookie: str | None = None,
+        csrf_token="bvyy75cEacX1ywOPQdOx1Xqf8dAztwxkNUnS9aKg20OUCkvGuc8Urs9R+MhvIWmcDR5iIo2los4cS7gTJ2VWNw==",
+        rate_limit_timer=4,
+    ):
+        """Initialize the HackerOne session.
 
-fragment HacktivityItemDisclosed on Disclosed {
-  id
-  report {
-    id
-    databaseId: _id
-    title
-    substate
-    url
-    __typename
-  }
-  total_awarded_amount
-  currency
-  __typename
-}
-"""
+        :param cookie: HackerOne cookie called __Host-session. Login to HackerOne and capture the cookie.
+        :param api_key: HackerOne API key.
+        """
+        self._cookie = cookie
+        self.rate_limit_timer = rate_limit_timer
 
-query_json={
-  'operationName': 'HacktivityPageQuery',
-  'variables': {
-    'querystring': '',
-    'where':{
-      'report':{
-        'disclosed_at':{
-          '_is_null': False
+        self.headers = {
+            "Content-Type": "application/json",
+            "__Host-session": cookie,
+            "X-Csrf-Token": csrf_token,
         }
-      }
-    },
-    'orderBy':{
-      'field':'popular',
-      'direction':'DESC'
-    },
-    'secureOrderBy':None,
-    'count': 100
-  },
-  'query':query_string
-}
+        self._session = httpx.Client(headers=self.headers, timeout=30)
 
+    @property
+    def graphql_url(self):
+        return "https://hackerone.com/graphql"
 
-hasNextPage = True
-count = 1
-while hasNextPage:
-  response = session.post(graphql_url, headers=headers, cookies=cookies, json=query_json)
-  respJson = response.json()
+    @property
+    def cookie(self) -> str | None:
+        return self._cookie
 
-  pageInfo =respJson['data']['hacktivity_items']['pageInfo']
-  if pageInfo['hasNextPage'] is False:
-    hasNextPage = False
-  
-  edges = respJson['data']['hacktivity_items']['edges']
-  for edge in edges:
-    try:
-      reportUrls.add(edge['node']['report']['url'])
-    except KeyError:
-      continue
+    @cookie.setter
+    def cookie(self, cookie: str):
+        self._cookie = cookie
+        self._session.headers["__Host-session"] = cookie
 
-  print(f"I have captured {len(reportUrls)} report urls now")
+    @property
+    def api_key(self) -> str | None:
+        return self._api_key
 
-  if hasNextPage:
-    count = count + 1
-    print(f"Going to cursor: {pageInfo['endCursor']}")
-    query_json={
-      'operationName': 'HacktivityPageQuery',
-      'variables': {
-        'querystring': '',
-        'where':{
-          'report':{
-            'disclosed_at':{
-              '_is_null': False
+    @api_key.setter
+    def api_key(self, api_key: str):
+        self._api_key = api_key
+        self._session.headers["Authorization"] = f"Bearer {api_key}"
+
+    def list_report_ids(self, rate_limit_timer=None) -> Generator[str, None, None]:
+        """List all hactivity report ids that are disclosed.
+
+        GraphQL taken from:
+        https://github.com/g0ldencybersec/sus_params/blob/main/hackerone.py
+
+        :param rate_limit_timer: Time to wait before retrying request.
+
+        :return: Generator of report ids.
+        """
+        if not rate_limit_timer:
+            rate_limit_timer = self.rate_limit_timer
+
+        if not self.cookie:
+            raise ValueError("Cookie is required to fetch reports.")
+
+        # Adjusted original query to only return relevant fields
+        query_string = """
+        query HacktivityPageQuery($querystring: String, $orderBy: HacktivityItemOrderInput, $secureOrderBy: FiltersHacktivityItemFilterOrder, $where: FiltersHacktivityItemFilterInput, $count: Int, $cursor: String) {
+        me {
+            id
+            __typename
+        }
+        hacktivity_items(
+            first: $count
+            after: $cursor
+            query: $querystring
+            order_by: $orderBy
+            secure_order_by: $secureOrderBy
+            where: $where
+        )   {
+                ...HacktivityList
             }
-          }
-        },
-        'orderBy':{
-          'field':'popular',
-          'direction':'DESC'
-        },
-        'secureOrderBy':None,
-        'count': 100,
-        "cursor":pageInfo['endCursor']
-      },
-      'query':query_string}
-  else:
-    print("Report Gathering Completed!")
-    hasNextPage = False
+        }
 
-print(f"Found {len(reportUrls)} report urls")
+        fragment HacktivityList on HacktivityItemConnection {
+        pageInfo {
+            endCursor
+            hasNextPage
+            __typename
+        }
+        edges {
+            node {
+            ... on HacktivityItemInterface {
+                    databaseId: _id
+                }
+            }
+        }
+        }
+        """
 
-vuln_list = []
-for url in reportUrls:
-  response = session.get(url+".json", headers=headers, cookies=cookies)
-  if response.status_code == 200:
-    new_vuln_info = {"id": response.json()['id'], "title":response.json()['title'], "vulnerability_information": response.json()['vulnerability_information'], "content": []}
-    if "weakness" in response.json().keys():
-      new_vuln_info['weakness'] = response.json()['weakness']
+        query_json = {
+            "operationName": "HacktivityPageQuery",
+            "variables": {
+                "querystring": "",
+                "where": {"report": {"disclosed_at": {"_is_null": False}}},
+                "orderBy": {"field": "popular", "direction": "DESC"},
+                "secureOrderBy": None,
+                "count": 100,
+            },
+            "query": query_string,
+        }
+
+        has_next_page = True
+        while has_next_page:
+            while True:
+                try:
+                    response = self._session.post(self.graphql_url, json=query_json)
+                except Exception as e:
+                    print(f"Error on {query_json}: {e}")
+                    sleep(rate_limit_timer)
+                    continue
+
+                if response.is_error:
+                    print(f"Error on {query_json}: {response.status_code}")
+                    sleep(rate_limit_timer)
+                    continue
+                break
+
+            data = response.json()
+            edges = data["data"]["hacktivity_items"]["edges"]
+
+            for edge in edges:
+                try:
+                    yield edge["node"]["databaseId"]
+                    # yield f"{edge['node']['report']['url']}.json"
+                except KeyError:
+                    continue
+
+            has_next_page = data["data"]["hacktivity_items"]["pageInfo"]["hasNextPage"]
+            if has_next_page is False:
+                break
+
+            query_json["variables"]["cursor"] = data["data"]["hacktivity_items"][
+                "pageInfo"
+            ]["endCursor"]
+
+    def list_reports(self, rate_limit_timer=None) -> Generator[dict, None, None]:
+        """Retrieve vulnerability reports from HackerOne.
+
+        :param rate_limit_timer: Time to wait before retrying request.
+
+        :return: Generator of reports dictionary represenation.
+        """
+        if not rate_limit_timer:
+            rate_limit_timer = self.rate_limit_timer
+
+        if not self.cookie:
+            raise ValueError("Cookie is required to fetch reports.")
+
+        for report_id in self.list_report_ids():
+            while True:
+                try:
+                    response = self._session.get(
+                        f"https://hackerone.com/reports/{report_id}.json"
+                    )
+                except Exception as e:
+                    print(f"ERROR - {report_id}: {e}")
+                    sleep(rate_limit_timer)
+                    continue
+
+                if response.is_error:
+                    print(f"ERROR - {report_id}: {response.status_code}")
+                    if response.status_code == 429:
+                        sleep(rate_limit_timer)
+                        continue
+                    else:
+                        raise
+                break
+
+            data = response.json()
+            if not data:
+                print(f"WARNING - {report_id}: No data found")
+                continue
+
+            try:
+                report = {
+                    "id": data["id"],
+                    "title": data["title"],
+                    "submitted_at": data["submitted_at"],
+                    "disclosed_at": data["disclosed_at"],
+                    "vulnerability_information": data["vulnerability_information"],
+                    "reporter": data["reporter"].get("username", ""),
+                    "program": data["team"]["handle"],
+                    "program_url": data["team"]["url"],
+                    "weakness": data.get("weakness"),
+                    "bounty": data.get("bounty_amount"),
+                    "severity": data.get("severity"),
+                    "structured_scope": data.get("structured_scope"),
+                    "content": [],
+                    "public": data.get("public"),
+                }
+
+                for summary in data.get("summaries", []):
+                    if "content" in summary:
+                        report["content"].append(summary["content"])
+
+                yield report
+            except Exception as e:
+                print(f"ERROR - {report_id}: {e}")
+
+    def write_hacktivity_reports_to_file(self, filename: str):
+        """Write all hacktivity reports to a file.
+
+        We will leverage generators to avoid loading all reports into memory and write
+        a report to the json file one at a time. To ensure the report is valid json,
+        we ensure to capture any errors and ctrl-c signals and close the file properly.
+        """
+
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write("[\n")
+
+            first_report = True
+            try:
+                for report in self.list_reports():
+                    if first_report:
+                        first_report = False
+                    else:
+                        print(f"{report['id']} - {report['title']}")
+                        f.write(",\n")
+
+                    json.dump(report, f, indent=None, separators=(",", ":"))
+            except Exception as e:
+                print(f"Error: {e}")
+            except KeyboardInterrupt:
+                pass
+
+            f.write("]\n")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="HackerOne hacktivity report scraper.")
+
+    parser.add_argument(
+        "--cookie",
+        help="HackerOne cookie called __Host-session. Login to HackerOne and capture the cookie.",
+    )
+    parser.add_argument(
+        "--filename",
+        help="Name of the json file to write the hacktivity reports to (defaults to 'hacktivity.json')",
+        default="hacktivity.json",
+    )
+
+    args = parser.parse_args()
+
+    if args.cookie is None:
+        cookie = input("Enter your HackerOne cookie called '__Host-session': ").strip()
     else:
-      new_vuln_info['weakness'] = {}
-    if "summaries" in response.json().keys():
-      for summary in response.json()['summaries']:
-        if "content" in summary.keys():
-          new_vuln_info['content'].append(summary['content'])
-    vuln_list.append(new_vuln_info)
-  else:
-    print(f"NONE 200 sc on {url}")
-    break
+        cookie = args.cookie
 
-with open('json_files/vulns.json', 'w') as fout:
-  json.dump(vuln_list, fout, indent=4)
-  fout.close()
-
-## Run processor
+    session = HackerOneSession(cookie=cookie)
+    session.write_hacktivity_reports_to_file(args.filename)


### PR DESCRIPTION
Hi batman & batman!

Thanks for sharing both the code and [interesting talk](https://www.youtube.com/watch?v=zInDWK43yQ8). Nice example of leveraging AI for fuzzy data analytics.

I wanted to grab Hacktivity reports for myself for a long time but never got around to it. I saw the hackerone.py script which already figured out how the graphql + report endpoints work so thought I bite the bullet.

This pull request refactors the hackerone.py script to make it a bit more robust by:
- handling errors and rate limits
- leverages generators to avoid having to keep all the reports / urls in memory during retrieval
- incrementally adds reports to the output file so a crash of the script won't lose all of the results


Create a new python virtual environment and install the dependency (Friends don't let other friends use system-level Python dependencies)

```sh
python3 -m venv .venv
source .venv/bin/activate
python3 -m pip install httpx

```

You can run the script as follows (use -h to see optional cli arguments like the cookie and/or filename from the command line):
```sh
chmod +x hackerone.py
./hackerone.py
```

Kind regards,
Robin

